### PR TITLE
Feature/seperate appviewmodel to each viewmodel

### DIFF
--- a/lib/ui/main.dart
+++ b/lib/ui/main.dart
@@ -79,8 +79,11 @@ class HomePage extends StatelessWidget {
                     itemExtent: 100,
                     delegate: SliverChildBuilderDelegate(
                         (BuildContext context, int index) {
-                      return Consumer<FineDustViewModel>(
-                        builder: (context, fineDust, child) {
+                      return Consumer2<UserLocationViewModel, FineDustViewModel>(
+                        builder: (context, userLocation, fineDust, child) {
+                          if(userLocation.position == null) {
+                            userLocation.refreshPosition();
+                          }
                           if (fineDust.isLoading == null || !fineDust.isLoading) {
                             updateFineDustInfo(context);
                             return Center(
@@ -96,6 +99,19 @@ class HomePage extends StatelessWidget {
               ),
             ),
           );
+  }
+
+  Widget loadingIndicator() {
+    Widget _indicatorWidget;
+
+    if(Platform.isAndroid) {
+      _indicatorWidget = Center(child: CircularProgressIndicator(),);
+    }
+    else if(Platform.isIOS) {
+      _indicatorWidget = Center(child: CupertinoActivityIndicator(),);
+    }
+
+    return _indicatorWidget;
   }
 
   void updateFineDustInfo(BuildContext context) {

--- a/lib/ui/main.dart
+++ b/lib/ui/main.dart
@@ -26,7 +26,6 @@ class MyApp extends StatelessWidget {
       child: Platform.isAndroid
           ? MaterialApp(
               title: 'Flutter Demo',
-              theme: ThemeData.dark(),
               home: HomePage(),
             )
           : CupertinoApp(
@@ -40,7 +39,6 @@ class MyApp extends StatelessWidget {
 }
 
 class HomePage extends StatelessWidget {
-
   UserLocationViewModel _userLocationViewModel;
   FineDustViewModel _fineDustViewModel;
   @override
@@ -50,7 +48,19 @@ class HomePage extends StatelessWidget {
 
     return Platform.isAndroid
         ? Scaffold(
-            body: returnWidget(),
+            appBar: AppBar(),
+            body: RefreshIndicator(
+                child: ListView(
+                  children: <Widget>[
+                    returnWidget(),
+                  ],
+                ),
+                onRefresh: () {
+                  return Future<void>.delayed(Duration(seconds: 1)).then((_) {
+                    updateFineDustInfo();
+                  });
+                }
+            ),
             floatingActionButton: FloatingActionButton(
               onPressed: () {
                 updateFineDustInfo();
@@ -73,7 +83,8 @@ class HomePage extends StatelessWidget {
                   ),
                   SliverFixedExtentList(
                     itemExtent: 100,
-                    delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                    delegate: SliverChildBuilderDelegate(
+                        (BuildContext context, int index) {
                       return returnWidget();
                     }, childCount: 1),
                   )
@@ -86,21 +97,22 @@ class HomePage extends StatelessWidget {
   Widget loadingIndicator() {
     Widget _indicatorWidget;
 
-    if(Platform.isAndroid) {
-      _indicatorWidget = Center(child: CircularProgressIndicator(),);
-    }
-    else if(Platform.isIOS) {
-      _indicatorWidget = Center(child: CupertinoActivityIndicator(),);
+    if (Platform.isAndroid) {
+      _indicatorWidget = Center(
+        child: CircularProgressIndicator(),
+      );
+    } else if (Platform.isIOS) {
+      _indicatorWidget = Center(
+        child: CupertinoActivityIndicator(),
+      );
     }
 
     return _indicatorWidget;
   }
 
   void updateFineDustInfo() {
-    _userLocationViewModel
-        .refreshPosition()
-        .then((_) {
-          _fineDustViewModel.getFineDustInfo(_userLocationViewModel.position);
+    _userLocationViewModel.refreshPosition().then((_) {
+      _fineDustViewModel.getFineDustInfo(_userLocationViewModel.position);
     });
   }
 
@@ -109,8 +121,7 @@ class HomePage extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          Text(
-              '현재 시간 - ${_fineDustViewModel.updatedDateTime.toString()}'),
+          Text('현재 시간 - ${_fineDustViewModel.updatedDateTime.toString()}'),
           SizedBox(
             height: 10,
           ),
@@ -134,14 +145,14 @@ class HomePage extends StatelessWidget {
   Widget returnWidget() {
     Widget returnWidget;
 
-    if(_userLocationViewModel.isLoading == null && _fineDustViewModel.isLoading == null) {
+    if (_userLocationViewModel.isLoading == null &&
+        _fineDustViewModel.isLoading == null) {
       updateFineDustInfo();
       returnWidget = loadingIndicator();
-    }
-    else if(_userLocationViewModel.isLoading || _fineDustViewModel.isLoading) {
+    } else if (_userLocationViewModel.isLoading ||
+        _fineDustViewModel.isLoading) {
       returnWidget = loadingIndicator();
-    }
-    else {
+    } else {
       returnWidget = showFineDustWidget();
     }
     return returnWidget;

--- a/lib/ui/main.dart
+++ b/lib/ui/main.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:misemeonjigadoeeo/viewmodel/app_viewmodel.dart';
 import 'package:misemeonjigadoeeo/viewmodel/fine_dust_viewmodel.dart';
 import 'package:misemeonjigadoeeo/viewmodel/user_location_viewmodel.dart';
 

--- a/lib/ui/main.dart
+++ b/lib/ui/main.dart
@@ -39,27 +39,7 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class HomePage extends StatefulWidget {
-  @override
-  _HomePageState createState() => _HomePageState();
-}
-
-class _HomePageState extends State<HomePage> {
-  UserLocationViewModel _userLocationViewModel;
-  FineDustViewModel _fineDustViewModel;
-
-  @override
-  void initState() {
-    // TODO: implement initState
-    super.initState();
-
-    _userLocationViewModel =
-        Provider.of<UserLocationViewModel>(context, listen: false);
-    _fineDustViewModel = Provider.of<FineDustViewModel>(context);
-
-    updateFineDustInfo();
-  }
-
+class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Platform.isAndroid
@@ -67,16 +47,17 @@ class _HomePageState extends State<HomePage> {
             body: Consumer<FineDustViewModel>(
               builder: (context, fineDust, child) {
                 if (fineDust.isLoaded == null || !fineDust.isLoaded) {
+                  updateFineDustInfo(context);
                   return Center(
                     child: CircularProgressIndicator(),
                   );
                 }
-                return showFineDustWidget();
+                return showFineDustWidget(context);
               },
             ),
             floatingActionButton: FloatingActionButton(
               onPressed: () {
-                updateFineDustInfo();
+                updateFineDustInfo(context);
               },
               tooltip: 'Increment',
               child: Icon(Icons.refresh),
@@ -90,7 +71,7 @@ class _HomePageState extends State<HomePage> {
                     onRefresh: () {
                       return Future<void>.delayed(const Duration(seconds: 1))
                         ..then<void>((_) {
-                          updateFineDustInfo();
+                          updateFineDustInfo(context);
                         });
                     },
                   ),
@@ -100,12 +81,13 @@ class _HomePageState extends State<HomePage> {
                         (BuildContext context, int index) {
                       return Consumer<FineDustViewModel>(
                         builder: (context, fineDust, child) {
-                          if (fineDust.isLoaded == null || fineDust.isLoaded) {
+                          if (fineDust.isLoaded == null || !fineDust.isLoaded) {
+                            updateFineDustInfo(context);
                             return Center(
                               child: CupertinoActivityIndicator(),
                             );
                           }
-                          return showFineDustWidget();
+                          return showFineDustWidget(context);
                         },
                       );
                     }, childCount: 1),
@@ -116,34 +98,41 @@ class _HomePageState extends State<HomePage> {
           );
   }
 
-  void updateFineDustInfo() {
-    _userLocationViewModel.refreshPosition().then((_) {
-      _fineDustViewModel.getFineDustInfo(_userLocationViewModel.position);
+  void updateFineDustInfo(BuildContext context) {
+    Provider.of<UserLocationViewModel>(context, listen: false)
+        .refreshPosition()
+        .then((_) {
+      Provider.of<FineDustViewModel>(context).getFineDustInfo(
+          Provider
+              .of<UserLocationViewModel>(context, listen: false)
+              .position);
     });
   }
 
-  Widget showFineDustWidget() {
+  Widget showFineDustWidget(BuildContext context) {
     return Center(
-        child: Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Text('현재 시간 - ${_fineDustViewModel.updatedDateTime.toString()}'),
-        SizedBox(
-          height: 10,
-        ),
-        Text(
-            '미세먼지 정보 : ${_fineDustViewModel.fineDustResponse.iaqi.pm25.v.toString()}'),
-        /*Text(locationPermission && userLocation != null
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Text(
+              '현재 시간 - ${Provider.of<FineDustViewModel>(context, listen: false).updatedDateTime.toString()}'),
+          SizedBox(
+            height: 10,
+          ),
+          Text(
+              '미세먼지 정보 : ${Provider.of<FineDustViewModel>(context, listen: false).fineDustResponse.iaqi.pm25.v.toString()}'),
+          /*Text(locationPermission && userLocation != null
                     ? '현재 위치 - ${userLocation.latitude}, ${userLocation.longitude}'
                     : '위치 권한 없음'),
                 SwitchListTile(
                     value: locationPermission,
                     onChanged: _permissionChange,
                     title: Text('위치 권한'))*/
-        // 위도 - userLocation.latitude
-        // 경도 - userLocation.longitude
-        // 고도 - userLocation.altitude
-      ],
-    ));
+          // 위도 - userLocation.latitude
+          // 경도 - userLocation.longitude
+          // 고도 - userLocation.altitude
+        ],
+      ),
+    );
   }
 }

--- a/lib/ui/main.dart
+++ b/lib/ui/main.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:misemeonjigadoeeo/viewmodel/app_viewmodel.dart';
+import 'package:misemeonjigadoeeo/viewmodel/fine_dust_viewmodel.dart';
+import 'package:misemeonjigadoeeo/viewmodel/user_location_viewmodel.dart';
 
 import 'package:provider/provider.dart';
 
@@ -13,112 +15,136 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider<AppViewModel>(
-      builder: (context) => AppViewModel(),
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          builder: (context) => UserLocationViewModel(),
+        ),
+        ChangeNotifierProvider(
+          builder: (context) => FineDustViewModel(),
+        ),
+      ],
       child: Platform.isAndroid
           ? MaterialApp(
-          title: 'Flutter Demo',
-          theme: ThemeData.dark(),
-          home: Consumer<AppViewModel>(
-              builder: (context, viewmodel, child) =>
-                  HomePage(appViewModel: viewmodel)))
+              title: 'Flutter Demo',
+              theme: ThemeData.dark(),
+              home: HomePage(),
+            )
           : CupertinoApp(
-          title: 'Flutter Demo',
-          theme: CupertinoThemeData(
-              primaryColor: CupertinoColors.lightBackgroundGray),
-          home: Consumer<AppViewModel>(
-              builder: (context, viewmodel, child) =>
-                  HomePage(appViewModel: viewmodel))),
+              title: 'Flutter Demo',
+              theme: CupertinoThemeData(
+                  primaryColor: CupertinoColors.lightBackgroundGray),
+              home: HomePage(),
+            ),
     );
   }
 }
 
-class HomePage extends StatelessWidget {
-  AppViewModel appViewModel;
+class HomePage extends StatefulWidget {
+  @override
+  _HomePageState createState() => _HomePageState();
+}
 
-  HomePage({this.appViewModel});
+class _HomePageState extends State<HomePage> {
+  UserLocationViewModel _userLocationViewModel;
+  FineDustViewModel _fineDustViewModel;
+
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+
+    _userLocationViewModel =
+        Provider.of<UserLocationViewModel>(context, listen: false);
+    _fineDustViewModel = Provider.of<FineDustViewModel>(context);
+
+    updateFineDustInfo();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Platform.isAndroid
         ? Scaffold(
-      body: appViewModel.position != null
-          ? appViewModel.fineDustResponse != null
-          ? showFineDustWidget()
-          : showLoadingProgressBarAndFetchFineDust()
-          : showLoadingProgressBarAndFetchPosition(),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          appViewModel.getFineDustInfo(appViewModel.position);
-        },
-        tooltip: 'Increment',
-        child: Icon(Icons.refresh),
-      ),
-    )
+            body: Consumer<FineDustViewModel>(
+              builder: (context, fineDust, child) {
+                if (fineDust.isLoaded == null || !fineDust.isLoaded) {
+                  return Center(
+                    child: CircularProgressIndicator(),
+                  );
+                }
+                return showFineDustWidget();
+              },
+            ),
+            floatingActionButton: FloatingActionButton(
+              onPressed: () {
+                updateFineDustInfo();
+              },
+              tooltip: 'Increment',
+              child: Icon(Icons.refresh),
+            ),
+          )
         : CupertinoPageScaffold(
-        child: SafeArea(
-          child: CustomScrollView(
-            slivers: <Widget>[
-              CupertinoSliverRefreshControl(
-                onRefresh: () {
-                  return Future<void>.delayed(const Duration(seconds: 1))
-                    ..then<void>((_) {
-                      appViewModel.getFineDustInfo(appViewModel.position);
-                    });
-                },
-              ),
-              SliverFixedExtentList(
-                itemExtent: 100,
-                delegate: SliverChildBuilderDelegate(
+            child: SafeArea(
+              child: CustomScrollView(
+                slivers: <Widget>[
+                  CupertinoSliverRefreshControl(
+                    onRefresh: () {
+                      return Future<void>.delayed(const Duration(seconds: 1))
+                        ..then<void>((_) {
+                          updateFineDustInfo();
+                        });
+                    },
+                  ),
+                  SliverFixedExtentList(
+                    itemExtent: 100,
+                    delegate: SliverChildBuilderDelegate(
                         (BuildContext context, int index) {
-                      return Center(
-                          child: Container(
-                            child: appViewModel.position != null
-                                ? appViewModel.fineDustResponse != null
-                                ? showFineDustWidget()
-                                : showLoadingProgressBarAndFetchFineDust()
-                                : showLoadingProgressBarAndFetchPosition(),
-                          ));
+                      return Consumer<FineDustViewModel>(
+                        builder: (context, fineDust, child) {
+                          if (fineDust.isLoaded == null || fineDust.isLoaded) {
+                            return Center(
+                              child: CupertinoActivityIndicator(),
+                            );
+                          }
+                          return showFineDustWidget();
+                        },
+                      );
                     }, childCount: 1),
-              )
-            ],
-          ),
-        ));
+                  )
+                ],
+              ),
+            ),
+          );
   }
 
-  Widget showLoadingProgressBarAndFetchPosition() {
-    appViewModel.refreshPosition();
-    return Center(child: CircularProgressIndicator());
-  }
-
-  Widget showLoadingProgressBarAndFetchFineDust() {
-    appViewModel.getFineDustInfo(appViewModel.position);
-    return Center(child: CircularProgressIndicator());
+  void updateFineDustInfo() {
+    _userLocationViewModel.refreshPosition().then((_) {
+      _fineDustViewModel.getFineDustInfo(_userLocationViewModel.position);
+    });
   }
 
   Widget showFineDustWidget() {
     return Center(
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text('현재 시간 - ${appViewModel.updatedDateTime.toString()}'),
-            SizedBox(
-              height: 10,
-            ),
-            Text(
-                '미세먼지 정보 : ${appViewModel.fineDustResponse.iaqi.pm25.v
-                    .toString()}'),
-            /*Text(locationPermission && userLocation != null
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        Text('현재 시간 - ${_fineDustViewModel.updatedDateTime.toString()}'),
+        SizedBox(
+          height: 10,
+        ),
+        Text(
+            '미세먼지 정보 : ${_fineDustViewModel.fineDustResponse.iaqi.pm25.v.toString()}'),
+        /*Text(locationPermission && userLocation != null
                     ? '현재 위치 - ${userLocation.latitude}, ${userLocation.longitude}'
                     : '위치 권한 없음'),
                 SwitchListTile(
                     value: locationPermission,
                     onChanged: _permissionChange,
                     title: Text('위치 권한'))*/
-            // 위도 - userLocation.latitude
-            // 경도 - userLocation.longitude
-            // 고도 - userLocation.altitude
-          ],
-        ));
+        // 위도 - userLocation.latitude
+        // 경도 - userLocation.longitude
+        // 고도 - userLocation.altitude
+      ],
+    ));
   }
 }

--- a/lib/ui/main.dart
+++ b/lib/ui/main.dart
@@ -46,7 +46,7 @@ class HomePage extends StatelessWidget {
         ? Scaffold(
             body: Consumer<FineDustViewModel>(
               builder: (context, fineDust, child) {
-                if (fineDust.isLoaded == null || !fineDust.isLoaded) {
+                if (fineDust.isLoading == null || !fineDust.isLoading) {
                   updateFineDustInfo(context);
                   return Center(
                     child: CircularProgressIndicator(),
@@ -81,7 +81,7 @@ class HomePage extends StatelessWidget {
                         (BuildContext context, int index) {
                       return Consumer<FineDustViewModel>(
                         builder: (context, fineDust, child) {
-                          if (fineDust.isLoaded == null || !fineDust.isLoaded) {
+                          if (fineDust.isLoading == null || !fineDust.isLoading) {
                             updateFineDustInfo(context);
                             return Center(
                               child: CupertinoActivityIndicator(),

--- a/lib/viewmodel/app_viewmodel.dart
+++ b/lib/viewmodel/app_viewmodel.dart
@@ -1,5 +1,0 @@
-import 'base_viewmodel.dart';
-import 'user_location_viewmodel.dart';
-import 'fine_dust_viewmodel.dart';
-
-class AppViewModel extends BaseViewModel with UserLocationViewModel, FineDustViewModel {}

--- a/lib/viewmodel/base_viewmodel.dart
+++ b/lib/viewmodel/base_viewmodel.dart
@@ -1,17 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 
-class BaseViewModel extends ChangeNotifier {
-  bool isLoaded;
-
-  void changeLoadingState() {
-    if(isLoaded == null) {
-      isLoaded = false;
-    }
-    else {
-      isLoaded = !isLoaded;
-    }
-
+class BaseViewModel with ChangeNotifier {
+  bool _isLoading = false;
+  get isLoading => _isLoading;
+  set isLoading(bool isLoading) {
+    _isLoading = isLoading;
     notifyListeners();
   }
 }

--- a/lib/viewmodel/base_viewmodel.dart
+++ b/lib/viewmodel/base_viewmodel.dart
@@ -2,9 +2,5 @@ import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 
 class BaseViewModel with ChangeNotifier {
-  bool _isLoading = false;
-  get isLoading => _isLoading;
-  set isLoading(bool isLoading) {
-    _isLoading = isLoading;
-  }
+  bool isLoading;
 }

--- a/lib/viewmodel/base_viewmodel.dart
+++ b/lib/viewmodel/base_viewmodel.dart
@@ -6,6 +6,5 @@ class BaseViewModel with ChangeNotifier {
   get isLoading => _isLoading;
   set isLoading(bool isLoading) {
     _isLoading = isLoading;
-    notifyListeners();
   }
 }

--- a/lib/viewmodel/base_viewmodel.dart
+++ b/lib/viewmodel/base_viewmodel.dart
@@ -3,4 +3,15 @@ import 'package:flutter/cupertino.dart';
 
 class BaseViewModel extends ChangeNotifier {
   bool isLoaded;
+
+  void changeLoadingState() {
+    if(isLoaded == null) {
+      isLoaded = false;
+    }
+    else {
+      isLoaded = !isLoaded;
+    }
+
+    notifyListeners();
+  }
 }

--- a/lib/viewmodel/fine_dust_viewmodel.dart
+++ b/lib/viewmodel/fine_dust_viewmodel.dart
@@ -11,10 +11,10 @@ class FineDustViewModel extends BaseViewModel {
   DateTime updatedDateTime;
 
   Future<void> getFineDustInfo(Position pos) async {
-    changeLoadingState();
+    isLoading = true;
     fineDustResponse = await fineDustService.getFineDustInfoByLatLng(pos);
     refreshDateTime();
-    changeLoadingState();
+    isLoading = false;
   }
 
   refreshDateTime() {

--- a/lib/viewmodel/fine_dust_viewmodel.dart
+++ b/lib/viewmodel/fine_dust_viewmodel.dart
@@ -15,6 +15,7 @@ class FineDustViewModel extends BaseViewModel {
     fineDustResponse = await fineDustService.getFineDustInfoByLatLng(pos);
     refreshDateTime();
     isLoading = false;
+    notifyListeners();
   }
 
   refreshDateTime() {

--- a/lib/viewmodel/fine_dust_viewmodel.dart
+++ b/lib/viewmodel/fine_dust_viewmodel.dart
@@ -4,18 +4,17 @@ import 'package:misemeonjigadoeeo/service/fine_dust_service.dart';
 
 import 'base_viewmodel.dart';
 
-mixin FineDustViewModel on BaseViewModel {
+class FineDustViewModel extends BaseViewModel {
 
   FineDustService fineDustService = FineDustService();
   FineDustResponse fineDustResponse;
   DateTime updatedDateTime;
 
-  getFineDustInfo(Position pos) async {
-    isLoaded = false;
+  Future<void> getFineDustInfo(Position pos) async {
+    changeLoadingState();
     fineDustResponse = await fineDustService.getFineDustInfoByLatLng(pos);
     refreshDateTime();
-    isLoaded = true;
-    notifyListeners();
+    changeLoadingState();
   }
 
   refreshDateTime() {

--- a/lib/viewmodel/user_location_viewmodel.dart
+++ b/lib/viewmodel/user_location_viewmodel.dart
@@ -3,15 +3,14 @@ import 'package:misemeonjigadoeeo/service/user_location_service.dart';
 
 import 'base_viewmodel.dart';
 
-mixin UserLocationViewModel on BaseViewModel {
+class UserLocationViewModel extends BaseViewModel {
 
   final UserLocationService userLocationService = UserLocationService();
   Position position;
 
-  refreshPosition() async {
-    isLoaded = false;
+  Future<void> refreshPosition() async {
+    changeLoadingState();
     position = await userLocationService.getLastKnownPosition();
-    isLoaded = true;
     notifyListeners();
   }
 }

--- a/lib/viewmodel/user_location_viewmodel.dart
+++ b/lib/viewmodel/user_location_viewmodel.dart
@@ -9,8 +9,8 @@ class UserLocationViewModel extends BaseViewModel {
   Position position;
 
   Future<void> refreshPosition() async {
-    changeLoadingState();
+    isLoading = true;
     position = await userLocationService.getLastKnownPosition();
-    notifyListeners();
+    isLoading = false;
   }
 }

--- a/lib/viewmodel/user_location_viewmodel.dart
+++ b/lib/viewmodel/user_location_viewmodel.dart
@@ -12,5 +12,6 @@ class UserLocationViewModel extends BaseViewModel {
     isLoading = true;
     position = await userLocationService.getLastKnownPosition();
     isLoading = false;
+    notifyListeners();
   }
 }


### PR DESCRIPTION
각 뷰모델 분리하여 MultiProvider로 각각의 뷰모델 주입시키게 변경하였습니다.
main.dart 에 returnWidget()이라는 함수를 만들어 최초 HomePage위젯 빌드시에는 updateFineDustInfo()함수를 호출하여 위치 및 미세먼지 정보를 가져오게 하였고 안드로이드, iOS 전부 스와이프 시 미세먼지 정보가 갱신되도록 수정하였습니다.
returnWidget()은 네이밍이 당장 떠오르지 않아서 임시로 네이밍을 하였고 현재 위젯 빌드 시 상태 별 (최초 빌드될 때, 위치 및 미세먼지 정보를 갱신하는 중일 때, 완료되었을 때)로 위젯을 반환합니다. 직관적인 네이밍이 있다면 코멘트 부탁드리겠습니다.